### PR TITLE
fix: correct license field to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": ["github", "action", "pr", "label", "size"],
   "author": "Conforma",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
The LICENSE file and README both specify Apache 2.0, but package.json incorrectly listed MIT.

Ref: EC-1735

Made with [Cursor](https://cursor.com)