### PR TITLE
EC-1738: Add unit tests for size label calculation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58499,7 +58499,7 @@ async function run() {
       return;
     }
     
-    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
+    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size: '));
     console.log(`Found ${sizeLabels.length} existing size labels to remove`);
     
     for (const label of sizeLabels) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -58426,6 +58426,117 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 5105:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const core = __nccwpck_require__(7484);
+const github = __nccwpck_require__(3228);
+
+/**
+ * Determines the size label based on total lines changed
+ * @param {number} size - Total lines changed (additions + deletions)
+ * @returns {string} Size label (XS, S, M, L, XL, or XXL)
+ */
+function getSizeLabel(size) {
+  if (size > 600) {
+    return 'XXL';
+  } else if (size > 240) {
+    return 'XL';
+  } else if (size > 120) {
+    return 'L';
+  } else if (size > 60) {
+    return 'M';
+  } else if (size > 35) {
+    return 'S';
+  }
+  return 'XS';
+}
+
+async function run() {
+  try {
+    const token = core.getInput('token');
+    const octokit = github.getOctokit(token);
+    
+    const { owner, repo } = github.context.repo;
+    const prNumber = github.context.payload.pull_request.number;
+    
+    console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);
+    
+    // Get PR details
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber
+    });
+    
+    const additions = pr.additions;
+    const deletions = pr.deletions;
+    const size = additions + deletions;
+    
+    console.log(`PR size: ${additions} additions + ${deletions} deletions = ${size} total changes`);
+    
+    // Determine size label
+    const sizeLabel = getSizeLabel(size);
+    
+    console.log(`Determined size label: ${sizeLabel}`);
+    
+    // Get current labels
+    const { data: currentLabels } = await octokit.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: prNumber
+    });
+    
+    const newLabel = `size: ${sizeLabel}`;
+    
+    // Check if the correct label already exists
+    const hasCorrectLabel = currentLabels.some(label => label.name === newLabel);
+    
+    if (hasCorrectLabel) {
+      console.log(`PR already has the correct label: ${newLabel}. No changes needed.`);
+      return;
+    }
+    
+    // Remove existing size labels (only if we need to change)
+    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
+    console.log(`Found ${sizeLabels.length} existing size labels to remove`);
+    
+    for (const label of sizeLabels) {
+      console.log(`Removing label: ${label.name}`);
+      await octokit.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: prNumber,
+        name: label.name
+      });
+    }
+    
+    // Add new size label
+    console.log(`Adding label: ${newLabel}`);
+    
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: prNumber,
+      labels: [newLabel]
+    });
+    
+    console.log(`Successfully labeled PR #${prNumber} with ${newLabel}`);
+    
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+module.exports = { getSizeLabel, run };
+
+if (require.main === require.cache[eval('__filename')]) {
+  run();
+}
+
+
+/***/ }),
+
 /***/ 2613:
 /***/ ((module) => {
 
@@ -60465,99 +60576,12 @@ module.exports = parseParams
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-const core = __nccwpck_require__(7484);
-const github = __nccwpck_require__(3228);
-
-async function run() {
-  try {
-    const token = core.getInput('token');
-    const octokit = github.getOctokit(token);
-    
-    const { owner, repo } = github.context.repo;
-    const prNumber = github.context.payload.pull_request.number;
-    
-    console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);
-    
-    // Get PR details
-    const { data: pr } = await octokit.rest.pulls.get({
-      owner,
-      repo,
-      pull_number: prNumber
-    });
-    
-    const additions = pr.additions;
-    const deletions = pr.deletions;
-    const size = additions + deletions;
-    
-    console.log(`PR size: ${additions} additions + ${deletions} deletions = ${size} total changes`);
-    
-    // Determine size label
-    let sizeLabel = 'XS';
-    if (size > 600) {
-      sizeLabel = 'XXL';
-    } else if (size > 240) {
-      sizeLabel = 'XL';
-    } else if (size > 120) {
-      sizeLabel = 'L';
-    } else if (size > 60) {
-      sizeLabel = 'M';
-    } else if (size > 35) {
-      sizeLabel = 'S';
-    }
-    
-    console.log(`Determined size label: ${sizeLabel}`);
-    
-    // Get current labels
-    const { data: currentLabels } = await octokit.rest.issues.listLabelsOnIssue({
-      owner,
-      repo,
-      issue_number: prNumber
-    });
-    
-    const newLabel = `size: ${sizeLabel}`;
-    
-    // Check if the correct label already exists
-    const hasCorrectLabel = currentLabels.some(label => label.name === newLabel);
-    
-    if (hasCorrectLabel) {
-      console.log(`PR already has the correct label: ${newLabel}. No changes needed.`);
-      return;
-    }
-    
-    // Remove existing size labels (only if we need to change)
-    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
-    console.log(`Found ${sizeLabels.length} existing size labels to remove`);
-    
-    for (const label of sizeLabels) {
-      console.log(`Removing label: ${label.name}`);
-      await octokit.rest.issues.removeLabel({
-        owner,
-        repo,
-        issue_number: prNumber,
-        name: label.name
-      });
-    }
-    
-    // Add new size label
-    console.log(`Adding label: ${newLabel}`);
-    
-    await octokit.rest.issues.addLabels({
-      owner,
-      repo,
-      issue_number: prNumber,
-      labels: [newLabel]
-    });
-    
-    console.log(`Successfully labeled PR #${prNumber} with ${newLabel}`);
-    
-  } catch (error) {
-    core.setFailed(error.message);
-  }
-}
-
-run();
-
-module.exports = __webpack_exports__;
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(5105);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -58462,7 +58462,6 @@ async function run() {
     
     console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);
     
-    // Get PR details
     const { data: pr } = await octokit.rest.pulls.get({
       owner,
       repo,
@@ -58475,12 +58474,10 @@ async function run() {
     
     console.log(`PR size: ${additions} additions + ${deletions} deletions = ${size} total changes`);
     
-    // Determine size label
     const sizeLabel = getSizeLabel(size);
     
     console.log(`Determined size label: ${sizeLabel}`);
     
-    // Get current labels
     const { data: currentLabels } = await octokit.rest.issues.listLabelsOnIssue({
       owner,
       repo,
@@ -58489,7 +58486,6 @@ async function run() {
     
     const newLabel = `size: ${sizeLabel}`;
     
-    // Check if the correct label already exists
     const hasCorrectLabel = currentLabels.some(label => label.name === newLabel);
     
     if (hasCorrectLabel) {
@@ -58497,7 +58493,6 @@ async function run() {
       return;
     }
     
-    // Remove existing size labels (only if we need to change)
     const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
     console.log(`Found ${sizeLabels.length} existing size labels to remove`);
     
@@ -58511,7 +58506,6 @@ async function run() {
       });
     }
     
-    // Add new size label
     console.log(`Adding label: ${newLabel}`);
     
     await octokit.rest.issues.addLabels({
@@ -58529,10 +58523,6 @@ async function run() {
 }
 
 module.exports = { getSizeLabel, run };
-
-if (require.main === require.cache[eval('__filename')]) {
-  run();
-}
 
 
 /***/ }),
@@ -60576,12 +60566,10 @@ module.exports = parseParams
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-/******/ 	
-/******/ 	// startup
-/******/ 	// Load entry module and return exports
-/******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(5105);
-/******/ 	module.exports = __webpack_exports__;
-/******/ 	
+var __webpack_exports__ = {};
+const { run } = __nccwpck_require__(5105);
+run();
+
+module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -58458,6 +58458,12 @@ async function run() {
     const octokit = github.getOctokit(token);
     
     const { owner, repo } = github.context.repo;
+
+    if (!github.context.payload.pull_request) {
+      core.setFailed('This action must be run on pull_request or pull_request_target events.');
+      return;
+    }
+
     const prNumber = github.context.payload.pull_request.number;
     
     console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
       "devDependencies": {
         "@vercel/ncc": "^0.38.0",
         "jest": "^30.0.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GitHub Action to automatically label PRs based on size",
   "main": "dist/index.js",
   "scripts": {
-    "build": "ncc build src/index.js -o dist",
+    "build": "ncc build src/main.js -o dist",
     "test": "jest"
   },
   "keywords": ["github", "action", "pr", "label", "size"],

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ async function run() {
       return;
     }
     
-    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
+    const sizeLabels = currentLabels.filter(label => label.name.startsWith('size: '));
     console.log(`Found ${sizeLabels.length} existing size labels to remove`);
     
     for (const label of sizeLabels) {

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,6 @@ async function run() {
     
     console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);
     
-    // Get PR details
     const { data: pr } = await octokit.rest.pulls.get({
       owner,
       repo,
@@ -44,12 +43,10 @@ async function run() {
     
     console.log(`PR size: ${additions} additions + ${deletions} deletions = ${size} total changes`);
     
-    // Determine size label
     const sizeLabel = getSizeLabel(size);
     
     console.log(`Determined size label: ${sizeLabel}`);
     
-    // Get current labels
     const { data: currentLabels } = await octokit.rest.issues.listLabelsOnIssue({
       owner,
       repo,
@@ -58,7 +55,6 @@ async function run() {
     
     const newLabel = `size: ${sizeLabel}`;
     
-    // Check if the correct label already exists
     const hasCorrectLabel = currentLabels.some(label => label.name === newLabel);
     
     if (hasCorrectLabel) {
@@ -66,7 +62,6 @@ async function run() {
       return;
     }
     
-    // Remove existing size labels (only if we need to change)
     const sizeLabels = currentLabels.filter(label => label.name.startsWith('size:'));
     console.log(`Found ${sizeLabels.length} existing size labels to remove`);
     
@@ -80,7 +75,6 @@ async function run() {
       });
     }
     
-    // Add new size label
     console.log(`Adding label: ${newLabel}`);
     
     await octokit.rest.issues.addLabels({
@@ -98,7 +92,3 @@ async function run() {
 }
 
 module.exports = { getSizeLabel, run };
-
-if (require.main === module) {
-  run();
-}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,26 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
+/**
+ * Determines the size label based on total lines changed
+ * @param {number} size - Total lines changed (additions + deletions)
+ * @returns {string} Size label (XS, S, M, L, XL, or XXL)
+ */
+function getSizeLabel(size) {
+  if (size > 600) {
+    return 'XXL';
+  } else if (size > 240) {
+    return 'XL';
+  } else if (size > 120) {
+    return 'L';
+  } else if (size > 60) {
+    return 'M';
+  } else if (size > 35) {
+    return 'S';
+  }
+  return 'XS';
+}
+
 async function run() {
   try {
     const token = core.getInput('token');
@@ -25,18 +45,7 @@ async function run() {
     console.log(`PR size: ${additions} additions + ${deletions} deletions = ${size} total changes`);
     
     // Determine size label
-    let sizeLabel = 'XS';
-    if (size > 600) {
-      sizeLabel = 'XXL';
-    } else if (size > 240) {
-      sizeLabel = 'XL';
-    } else if (size > 120) {
-      sizeLabel = 'L';
-    } else if (size > 60) {
-      sizeLabel = 'M';
-    } else if (size > 35) {
-      sizeLabel = 'S';
-    }
+    const sizeLabel = getSizeLabel(size);
     
     console.log(`Determined size label: ${sizeLabel}`);
     
@@ -88,4 +97,8 @@ async function run() {
   }
 }
 
-run();
+module.exports = { getSizeLabel, run };
+
+if (require.main === module) {
+  run();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,12 @@ async function run() {
     const octokit = github.getOctokit(token);
     
     const { owner, repo } = github.context.repo;
+
+    if (!github.context.payload.pull_request) {
+      core.setFailed('This action must be run on pull_request or pull_request_target events.');
+      return;
+    }
+
     const prNumber = github.context.payload.pull_request.number;
     
     console.log(`Processing PR #${prNumber} in ${owner}/${repo}`);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,9 @@
-const { getSizeLabel } = require('./index');
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+const core = require('@actions/core');
+const github = require('@actions/github');
+const { getSizeLabel, run } = require('./index');
 
 describe('getSizeLabel', () => {
   describe('XS size (0-35 lines)', () => {
@@ -85,13 +90,6 @@ describe('getSizeLabel', () => {
     });
   });
 });
-
-jest.mock('@actions/core');
-jest.mock('@actions/github');
-
-const core = require('@actions/core');
-const github = require('@actions/github');
-const { run } = require('./index');
 
 describe('run()', () => {
   const mockOctokit = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -85,3 +85,83 @@ describe('getSizeLabel', () => {
     });
   });
 });
+
+jest.mock('@actions/core');
+jest.mock('@actions/github');
+
+const core = require('@actions/core');
+const github = require('@actions/github');
+const { run } = require('./index');
+
+describe('run()', () => {
+  const mockOctokit = {
+    rest: {
+      pulls: { get: jest.fn() },
+      issues: {
+        listLabelsOnIssue: jest.fn(),
+        removeLabel: jest.fn(),
+        addLabels: jest.fn()
+      }
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    core.getInput.mockReturnValue('fake-token');
+    github.getOctokit.mockReturnValue(mockOctokit);
+    github.context = {
+      repo: { owner: 'org', repo: 'repo' },
+      payload: { pull_request: { number: 42 } }
+    };
+  });
+
+  test('adds correct size label when no labels exist', async () => {
+    mockOctokit.rest.pulls.get.mockResolvedValue({ data: { additions: 10, deletions: 5 } });
+    mockOctokit.rest.issues.listLabelsOnIssue.mockResolvedValue({ data: [] });
+    await run();
+    expect(mockOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ['size: XS'] })
+    );
+  });
+
+  test('replaces existing size label when size changes', async () => {
+    mockOctokit.rest.pulls.get.mockResolvedValue({ data: { additions: 500, deletions: 200 } });
+    mockOctokit.rest.issues.listLabelsOnIssue.mockResolvedValue({
+      data: [{ name: 'size: XS' }, { name: 'bug' }]
+    });
+    await run();
+    expect(mockOctokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'size: XS' })
+    );
+    expect(mockOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ['size: XXL'] })
+    );
+  });
+
+  test('skips update when correct label already present', async () => {
+    mockOctokit.rest.pulls.get.mockResolvedValue({ data: { additions: 10, deletions: 5 } });
+    mockOctokit.rest.issues.listLabelsOnIssue.mockResolvedValue({
+      data: [{ name: 'size: XS' }]
+    });
+    await run();
+    expect(mockOctokit.rest.issues.addLabels).not.toHaveBeenCalled();
+    expect(mockOctokit.rest.issues.removeLabel).not.toHaveBeenCalled();
+  });
+
+  test('fails gracefully on non-PR events', async () => {
+    github.context = {
+      repo: { owner: 'org', repo: 'repo' },
+      payload: {}
+    };
+    await run();
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'This action must be run on pull_request or pull_request_target events.'
+    );
+  });
+
+  test('calls core.setFailed on API error', async () => {
+    mockOctokit.rest.pulls.get.mockRejectedValue(new Error('API error'));
+    await run();
+    expect(core.setFailed).toHaveBeenCalledWith('API error');
+  });
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,87 @@
+const { getSizeLabel } = require('./index');
+
+describe('getSizeLabel', () => {
+  describe('XS size (0-35 lines)', () => {
+    test('returns XS for 0 lines', () => {
+      expect(getSizeLabel(0)).toBe('XS');
+    });
+
+    test('returns XS for 1 line', () => {
+      expect(getSizeLabel(1)).toBe('XS');
+    });
+
+    test('returns XS for 35 lines (boundary)', () => {
+      expect(getSizeLabel(35)).toBe('XS');
+    });
+  });
+
+  describe('S size (36-60 lines)', () => {
+    test('returns S for 36 lines (boundary)', () => {
+      expect(getSizeLabel(36)).toBe('S');
+    });
+
+    test('returns S for 50 lines', () => {
+      expect(getSizeLabel(50)).toBe('S');
+    });
+
+    test('returns S for 60 lines (boundary)', () => {
+      expect(getSizeLabel(60)).toBe('S');
+    });
+  });
+
+  describe('M size (61-120 lines)', () => {
+    test('returns M for 61 lines (boundary)', () => {
+      expect(getSizeLabel(61)).toBe('M');
+    });
+
+    test('returns M for 90 lines', () => {
+      expect(getSizeLabel(90)).toBe('M');
+    });
+
+    test('returns M for 120 lines (boundary)', () => {
+      expect(getSizeLabel(120)).toBe('M');
+    });
+  });
+
+  describe('L size (121-240 lines)', () => {
+    test('returns L for 121 lines (boundary)', () => {
+      expect(getSizeLabel(121)).toBe('L');
+    });
+
+    test('returns L for 180 lines', () => {
+      expect(getSizeLabel(180)).toBe('L');
+    });
+
+    test('returns L for 240 lines (boundary)', () => {
+      expect(getSizeLabel(240)).toBe('L');
+    });
+  });
+
+  describe('XL size (241-600 lines)', () => {
+    test('returns XL for 241 lines (boundary)', () => {
+      expect(getSizeLabel(241)).toBe('XL');
+    });
+
+    test('returns XL for 400 lines', () => {
+      expect(getSizeLabel(400)).toBe('XL');
+    });
+
+    test('returns XL for 600 lines (boundary)', () => {
+      expect(getSizeLabel(600)).toBe('XL');
+    });
+  });
+
+  describe('XXL size (601+ lines)', () => {
+    test('returns XXL for 601 lines (boundary)', () => {
+      expect(getSizeLabel(601)).toBe('XXL');
+    });
+
+    test('returns XXL for 1000 lines', () => {
+      expect(getSizeLabel(1000)).toBe('XXL');
+    });
+
+    test('returns XXL for very large PRs', () => {
+      expect(getSizeLabel(10000)).toBe('XXL');
+    });
+  });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,2 @@
+const { run } = require('./index');
+run();


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests and improves the action's compliance with GitHub Actions best practices.

### Changes

- **Separate entrypoint from testable logic** — `src/main.js` is the new ncc build entrypoint that calls `run()` unconditionally. `src/index.js` is a pure module exporting `getSizeLabel` and `run` with no side effects on import. This eliminates the `require.main === module` guard that ncc transforms unreliably.
- **Guard against non-PR events** — `run()` now fails with a clear message instead of a TypeError when triggered outside `pull_request`/`pull_request_target` events.
- **Tighten label filter** — `startsWith('size:')` narrowed to `startsWith('size: ')` to avoid matching labels that don't follow this action's format.
- **Add 23 tests** — 18 boundary tests for `getSizeLabel` across all six size tiers, plus 5 `run()` tests covering label add, label replace, no-op, non-PR event guard, and API error propagation.
- **Rebuild dist** — `dist/index.js` regenerated from new entrypoint.

### Review notes

- `dist/index.js` changes are mechanical rebuilds — sanity check only
- `package-lock.json` changes reflect upstream merges
- CodeRabbit local review: no findings (2 clean passes)
- Qodo self-review: all suggestions addressed or intentionally skipped

Ref: EC-1738