### PR TITLE
ci: add release workflow with major version tag management

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v1.2.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ inputs.version }}" \
+            --generate-notes \
+            --title "${{ inputs.version }}"
+
+      - name: Update major version tag
+        run: |
+          MAJOR=$(echo "${{ inputs.version }}" | grep -oP '^v\d+')
+          git tag -f "${MAJOR}" "${{ inputs.version }}"
+          git push origin "${MAJOR}" --force

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,21 +29,51 @@ permissions:
 
 jobs:
   release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "${VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version must match format vX.Y.Z (e.g., v1.2.0)"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
         run: |
-          gh release create "${{ inputs.version }}" \
+          gh release create "${VERSION}" \
             --generate-notes \
-            --title "${{ inputs.version }}"
+            --title "${VERSION}"
+
+      - name: Fetch release tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git fetch --tags
+          if ! git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Expected tag '${VERSION}' to exist after release creation"
+            exit 1
+          fi
 
       - name: Update major version tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          MAJOR=$(echo "${{ inputs.version }}" | grep -oP '^v\d+')
-          git tag -f "${MAJOR}" "${{ inputs.version }}"
+          MAJOR=$(echo "${VERSION}" | grep -oE '^v[0-9]+')
+          git tag -f "${MAJOR}" "${VERSION}"
           git push origin "${MAJOR}" --force


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` release workflow (`.github/workflows/release.yaml`)
- Creates a GitHub release with auto-generated notes for the given version tag
- Updates the floating major version tag (e.g., `v1`) so consumers pinned to `@v1` get non-breaking updates automatically

This is the standard release pattern for GitHub Actions. Future releases can be cut via the Actions UI or `gh workflow run release.yaml -f version=vX.Y.Z`.

## Test plan

- [ ] Merge this PR
- [ ] Use the workflow to cut v1.1.0 (validates the workflow end-to-end)

Ref: EC-1752

Made with [Cursor](https://cursor.com)